### PR TITLE
Remove .tm_properties

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -9,6 +9,8 @@
   # signingkey = 0B5CA946
 [github]
   user = mylesborins
+
+  
 [color]
   diff = true
   ui = auto

--- a/.tm_properties
+++ b/.tm_properties
@@ -1,2 +1,0 @@
-include = "{$include,.*}"
-exclude = "{$exclude,.git}" 


### PR DESCRIPTION
This pull request includes a small change to the `.tm_properties` file. The change removes the `include` and `exclude` properties, which were used to specify file inclusion and exclusion patterns.